### PR TITLE
Add Linux AppImage support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Build and Release AppImage
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y wget libfuse2 python3-tk tk-dev
+
+      - name: Download appimagetool
+        run: |
+          wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x appimagetool-x86_64.AppImage
+
+      - name: Build AppImage
+        run: bash build-appimage.sh
+
+      - name: Get tag name
+        id: tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Rename AppImage with tag
+        run: |
+          TAG=${{ steps.tag.outputs.tag }}
+          APPIMAGE=$(ls QualityScaler-*.AppImage | head -1)
+          RENAMED="QualityScaler-${TAG}-x86_64.AppImage"
+          [ "$APPIMAGE" != "$RENAMED" ] && mv "$APPIMAGE" "$RENAMED" || true
+          echo "APPIMAGE_PATH=$RENAMED" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: QualityScaler ${{ steps.tag.outputs.tag }}
+          body: |
+            ## QualityScaler ${{ steps.tag.outputs.tag }}
+
+            ### Installation
+            1. Download `QualityScaler-${{ steps.tag.outputs.tag }}-x86_64.AppImage`
+            2. Make it executable: `chmod +x QualityScaler-*.AppImage`
+            3. Run it: `./QualityScaler-*.AppImage`
+
+            **GPU acceleration:** CUDA 11 libraries are bundled. An NVIDIA GPU with driver 450+ is recommended but the app will fall back to CPU automatically.
+          files: ${{ env.APPIMAGE_PATH }}
+          draft: false
+          prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Virtual environment
+.venv/
+
+# PyInstaller
+build/
+dist/
+*.spec.bak
+
+# AppImage build artifacts
+AppDir/
+*.AppImage
+
+# Downloaded build tools (re-downloaded automatically by build-appimage.sh)
+appimagetool-x86_64.AppImage
+
+# Downloaded static binaries (re-downloaded automatically by build-appimage.sh)
+Assets/ffmpeg
+Assets/exiftool
+Assets/exiftool_lib/
+
+# AI models — large files, downloaded separately
+# See README for download link (gofile.io)
+AI-onnx/*.onnx
+
+# User preference files generated at runtime
+*.json
+
+# Logs and temp files
+*.log
+*.tmp
+cale_steps*
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+CLAUDE.md

--- a/QualityScaler.py
+++ b/QualityScaler.py
@@ -4,7 +4,7 @@ import sys
 from functools  import cache
 from time       import sleep
 from webbrowser import open as open_browser
-from subprocess import run as subprocess_run
+from subprocess import run as subprocess_run, DEVNULL as subprocess_DEVNULL
 from shutil     import rmtree as remove_directory
 from timeit     import default_timer as timer
 
@@ -50,19 +50,23 @@ from os.path import (
     expanduser as os_path_expanduser
 )
 
-from subprocess import (
-    Popen                as subprocess_Popen,
-    STARTUPINFO          as subprocess_STARTUPINFO,
-    STARTF_USESHOWWINDOW as subprocess_STARTF_USESHOWWINDOW
-)
+from subprocess import Popen as subprocess_Popen
+if sys.platform == "win32":
+    from subprocess import (
+        STARTUPINFO          as subprocess_STARTUPINFO,
+        STARTF_USESHOWWINDOW as subprocess_STARTF_USESHOWWINDOW
+    )
 
 # Third-party library imports
 from natsort import natsorted
 from psutil import (
-    Process             as psutil_Process,
-    IDLE_PRIORITY_CLASS as psutil_IDLE_PRIORITY_CLASS,
-    virtual_memory      as psutil_virtual_memory,
+    Process        as psutil_Process,
+    virtual_memory as psutil_virtual_memory,
 )
+if sys.platform == "win32":
+    from psutil import IDLE_PRIORITY_CLASS as psutil_IDLE_PRIORITY_CLASS
+else:
+    psutil_IDLE_PRIORITY_CLASS = 19  # POSIX nice value: lowest priority
 from onnxruntime import (
     InferenceSession        as onnxruntime_InferenceSession,
     SessionOptions          as onnxruntime_SessionOptions,
@@ -74,6 +78,7 @@ from PIL.Image import (
     open      as pillow_image_open,
     fromarray as pillow_image_fromarray
 )
+from PIL import ImageTk
 
 from cv2 import (
     CAP_PROP_FPS,
@@ -204,10 +209,17 @@ video_codec_list = [
     ]
 
 OUTPUT_PATH_CODED    = "Same path as input files"
-DOCUMENT_PATH        = os_path_join(os_path_expanduser('~'), 'Documents')
+if sys.platform == "win32":
+    DOCUMENT_PATH = os_path_join(os_path_expanduser('~'), 'Documents')
+else:
+    DOCUMENT_PATH = os_path_expanduser('~')
 USER_PREFERENCE_PATH = find_by_relative_path(f"{DOCUMENT_PATH}{os_separator}{app_name}_{version}_userpreference.json")
-FFMPEG_EXE_PATH      = find_by_relative_path(f"Assets{os_separator}ffmpeg.exe")
-EXIFTOOL_EXE_PATH    = find_by_relative_path(f"Assets{os_separator}exiftool.exe")
+if sys.platform == "win32":
+    FFMPEG_EXE_PATH   = find_by_relative_path(f"Assets{os_separator}ffmpeg.exe")
+    EXIFTOOL_EXE_PATH = find_by_relative_path(f"Assets{os_separator}exiftool.exe")
+else:
+    FFMPEG_EXE_PATH   = find_by_relative_path(f"Assets{os_separator}ffmpeg")
+    EXIFTOOL_EXE_PATH = find_by_relative_path(f"Assets{os_separator}exiftool")
 
 COMPLETED_STATUS = "Completed"
 ERROR_STATUS     = "Error"
@@ -299,15 +311,27 @@ class AI_upscale:
 
     def _load_inferenceSession(self) -> onnxruntime_InferenceSession:
 
-        providers = ['DmlExecutionProvider']
-        #providers = ['WebGpuExecutionProvider']
-
-        match self.selected_gpu:
-            case 'Auto':  provider_options = [{"performance_preference": "high_performance"}]
-            case 'GPU 1': provider_options = [{"device_id": "0"}]
-            case 'GPU 2': provider_options = [{"device_id": "1"}]
-            case 'GPU 3': provider_options = [{"device_id": "2"}]
-            case 'GPU 4': provider_options = [{"device_id": "3"}]
+        if sys.platform == "win32":
+            providers = ['DmlExecutionProvider']
+            match self.selected_gpu:
+                case 'Auto':  provider_options = [{"performance_preference": "high_performance"}]
+                case 'GPU 1': provider_options = [{"device_id": "0"}]
+                case 'GPU 2': provider_options = [{"device_id": "1"}]
+                case 'GPU 3': provider_options = [{"device_id": "2"}]
+                case 'GPU 4': provider_options = [{"device_id": "3"}]
+        else:
+            providers = ['CUDAExecutionProvider']
+            _cuda_opts = {
+                "arena_extend_strategy":  "kSameAsRequested",
+                "gpu_mem_limit":          str(6 * 1024 * 1024 * 1024),  # 6 GB cap
+                "cudnn_conv_algo_search": "HEURISTIC",
+            }
+            match self.selected_gpu:
+                case 'Auto':  provider_options = [{**_cuda_opts, "device_id": 0}]
+                case 'GPU 1': provider_options = [{**_cuda_opts, "device_id": 0}]
+                case 'GPU 2': provider_options = [{**_cuda_opts, "device_id": 1}]
+                case 'GPU 3': provider_options = [{**_cuda_opts, "device_id": 2}]
+                case 'GPU 4': provider_options = [{**_cuda_opts, "device_id": 3}]
 
         sess_options = onnxruntime_SessionOptions()
         sess_options.enable_profiling = False
@@ -1555,7 +1579,7 @@ def copy_file_metadata(
     ]
     
     try: 
-        subprocess_run(exiftool_cmd, check = True, shell = "False")
+        subprocess_run(exiftool_cmd, check=True, shell=False, stdin=subprocess_DEVNULL)
     except:
         pass
 
@@ -2150,7 +2174,7 @@ def upscale_video(
 
         ffmpeg_process = None
         try:
-            ffmpeg_process = subprocess_Popen(extraction_command, startupinfo = startupinfo)
+            ffmpeg_process = subprocess_Popen(extraction_command, startupinfo=startupinfo, stdin=subprocess_DEVNULL)
             try: psutil_Process(ffmpeg_process.pid).nice(psutil_IDLE_PRIORITY_CLASS)
             except Exception: pass
             while ffmpeg_process.poll() is None:
@@ -2355,7 +2379,8 @@ def upscale_video(
         with os_fdopen(os_open(video_upscale_task.ffmpeg_txt_file_path, os_O_WRONLY | os_O_CREAT, 0o777), 'w', encoding="utf-8") as txt:
             for frame_path in video_upscale_task.upscaled_frame_paths:
                 if os_path_exists(frame_path):
-                    txt.write(f"file '{os_path_abspath(frame_path).replace("\\", "/")}' \n")
+                    normalized = os_path_abspath(frame_path).replace("\\", "/")
+                    txt.write(f"file '{normalized}' \n")
 
         # Create the upscaled video trying with selected codec OR x264 codec fallback
         codecs_to_try = [video_upscale_task.effective_codec, "libx264"]
@@ -2384,7 +2409,7 @@ def upscale_video(
                     "-b:v",        "50000k",
                     str(video_upscale_task.video_output_path)
                 ]
-                subprocess_run(encoding_command, check = True, shell = "False")
+                subprocess_run(encoding_command, check=True, shell=False, stdin=subprocess_DEVNULL)
                 delete_file(video_upscale_task.ffmpeg_txt_file_path)
                 print(f"[FFMPEG] encoding completed with ({current_codec})")
                 break
@@ -2558,6 +2583,57 @@ def get_upscale_factor() -> int:
 
     return upscale_factor
 
+def _native_file_dialog(mode: str) -> list[str]:
+    # mode: "files" for multi-file pick, "directory" for folder pick
+    # Try zenity (GNOME/GTK), then kdialog (KDE), then fall back to tkinter.
+    from shutil import which
+    exts = " ".join(f"*{e}" for e in supported_file_extensions)
+
+    if which("zenity"):
+        try:
+            if mode == "files":
+                result = subprocess_run(
+                    ["zenity", "--file-selection", "--multiple", "--separator=\n",
+                     "--file-filter=Supported files | " + exts,
+                     "--file-filter=All files | *"],
+                    capture_output=True, text=True
+                )
+            else:
+                result = subprocess_run(
+                    ["zenity", "--file-selection", "--directory"],
+                    capture_output=True, text=True
+                )
+            if result.returncode == 0:
+                return [p for p in result.stdout.strip().splitlines() if p]
+        except Exception:
+            pass
+
+    if which("kdialog"):
+        try:
+            if mode == "files":
+                filter_str = "Supported files (" + " ".join(f"*{e}" for e in supported_file_extensions) + ")"
+                result = subprocess_run(
+                    ["kdialog", "--getopenfilename", ".", filter_str, "--multiple"],
+                    capture_output=True, text=True
+                )
+            else:
+                result = subprocess_run(
+                    ["kdialog", "--getexistingdirectory", "."],
+                    capture_output=True, text=True
+                )
+            if result.returncode == 0:
+                return [p for p in result.stdout.strip().splitlines() if p]
+        except Exception:
+            pass
+
+    # Tkinter fallback
+    if mode == "files":
+        return list(filedialog.askopenfilenames())
+    else:
+        path = filedialog.askdirectory()
+        return [path] if path else []
+
+
 def open_files_action():
 
     def check_supported_selected_files(uploaded_file_list: list) -> list:
@@ -2565,7 +2641,7 @@ def open_files_action():
 
     info_message.set("Selecting files")
 
-    uploaded_files_list    = list(filedialog.askopenfilenames())
+    uploaded_files_list    = _native_file_dialog("files")
     uploaded_files_counter = len(uploaded_files_list)
 
     supported_files_list    = check_supported_selected_files(uploaded_files_list)
@@ -2593,7 +2669,8 @@ def open_files_action():
         info_message.set("Not supported files :(")
 
 def open_output_path_action():
-    asked_selected_output_path = filedialog.askdirectory()
+    result = _native_file_dialog("directory")
+    asked_selected_output_path = result[0] if result else ""
     if asked_selected_output_path == "":
         selected_output_path.set(OUTPUT_PATH_CODED)
     else:
@@ -3333,7 +3410,11 @@ class App():
         window.title(f"{self._get_AI_engine_info()}")
         window.geometry("1000x675")
         window.resizable(False, False)
-        window.iconbitmap(find_by_relative_path("Assets" + os_separator + "logo.ico"))
+        if sys.platform == "win32":
+            window.iconbitmap(find_by_relative_path("Assets" + os_separator + "logo.ico"))
+        else:
+            icon_img = pillow_image_open(find_by_relative_path("Assets" + os_separator + "logo.png"))
+            window.iconphoto(True, ImageTk.PhotoImage(icon_img))
 
         place_loadFile_section()
 
@@ -3366,6 +3447,11 @@ class App():
 # Main functions ---------------------------
 
 if __name__ == "__main__":
+
+    multiprocessing_freeze_support()
+    if sys.platform != "win32":
+        from multiprocessing import set_start_method
+        set_start_method("spawn", force=True)
 
     if os_path_exists(USER_PREFERENCE_PATH):
         print(f"[{app_name}] Preference file exist")
@@ -3400,7 +3486,6 @@ if __name__ == "__main__":
         default_output_resize_factor = str(100)
         default_VRAM_limiter         = str(4)
 
-    multiprocessing_freeze_support()
     set_appearance_mode("Dark")
     set_default_color_theme("dark-blue")
     apply_app_zoom(float(default_app_zoom.replace("%", "")) / 100)
@@ -3461,7 +3546,7 @@ if __name__ == "__main__":
     selected_input_resize_factor.trace_add('write', update_file_widget)
     selected_output_resize_factor.trace_add('write', update_file_widget)
 
-    font   = "Segoe UI"    
+    font   = "Segoe UI" if sys.platform == "win32" else "DejaVu Sans"
     bold8  = CTkFont(family = font, size = 8, weight = "bold")
     bold9  = CTkFont(family = font, size = 9, weight = "bold")
     bold10 = CTkFont(family = font, size = 10, weight = "bold")

--- a/QualityScaler.spec
+++ b/QualityScaler.spec
@@ -1,0 +1,64 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import os
+import sys
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+
+block_cipher = None
+
+a = Analysis(
+    ['QualityScaler.py'],
+    pathex=[],
+    binaries=collect_dynamic_libs('onnxruntime'),
+    datas=[
+        ('Assets',       'Assets'),
+        ('AI-onnx',      'AI-onnx'),
+    ] + (
+        [('Assets/exiftool_lib', 'Assets/exiftool_lib')] if os.path.isdir('Assets/exiftool_lib') else []
+    ) + collect_data_files('customtkinter'),
+    hiddenimports=[
+        'onnxruntime',
+        'onnxruntime.capi',
+        'onnxruntime.capi._pybind_state',
+        'PIL._tkinter_finder',
+        'PIL.ImageTk',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='QualityScaler',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='QualityScaler',
+)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,31 @@ Getting started.
 - Close VSCode and re-open it (this will refresh all the dependecies installed)
 - Click on the "Play button" in the upper right corner of VSCode
 
+## Make it work on Linux. 🐧
+Prerequisites.
+- Python 3.11 (`sudo dnf install python3.11` or `sudo apt install python3.11 python3.11-venv`)
+- AI models downloaded (https://gofile.io/d/b4Ds9u) placed in `/AI-onnx` folder
+- NVIDIA GPU with >= 4GB VRAM, driver 450+, Pascal (GTX 10xx) architecture or newer
+- `appimagetool` downloaded once into the repo root:
+```
+wget "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+chmod +x appimagetool-x86_64.AppImage
+```
+
+Getting started.
+```
+python3.11 -m venv .venv
+source .venv/bin/activate
+bash build-appimage.sh
+```
+The build script downloads static ffmpeg and exiftool binaries on first run, installs all Python dependencies including CUDA libraries, and packages the app as a self-contained AppImage.
+
+Or download the pre-built AppImage from the [Releases](../../releases) page, make it executable, and run:
+```
+chmod +x QualityScaler-*-x86_64.AppImage
+./QualityScaler-*-x86_64.AppImage
+```
+
 ## Requirements. 🤓
 - Windows 11 / Windows 10
 - RAM >= 8Gb
@@ -144,5 +169,3 @@ https://user-images.githubusercontent.com/32263112/209139639-2b123b83-ac6e-4681-
 ![Bsrgan x4 (3)](https://user-images.githubusercontent.com/32263112/197983979-5857a855-d402-4fab-9217-ee5bd057bd01.png)
 
 ![Bsrgan x4](https://user-images.githubusercontent.com/32263112/198290909-277e176e-ccb4-4a4b-8531-b182a18d566a.png)
-
-

--- a/build-appimage.sh
+++ b/build-appimage.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Builds QualityScaler as a Linux AppImage.
+# Requirements: python3.11, pip, appimagetool (in PATH or ./appimagetool-x86_64.AppImage)
+# GPU: onnxruntime-gpu 1.18.x requires CUDA 11 libraries at runtime (bundled automatically).
+
+set -euo pipefail
+
+APPNAME="QualityScaler"
+VERSION="2026.3"
+APPDIR="AppDir"
+
+# ── Bundle static ffmpeg ──────────────────────────────────────────────────────
+FFMPEG_DEST="Assets/ffmpeg"
+if [ ! -f "$FFMPEG_DEST" ]; then
+    echo "==> Downloading static ffmpeg..."
+    FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
+    TMP_DIR=$(mktemp -d)
+    wget -q --show-progress -O "$TMP_DIR/ffmpeg.tar.xz" "$FFMPEG_URL"
+    tar -xf "$TMP_DIR/ffmpeg.tar.xz" -C "$TMP_DIR" --strip-components=1
+    cp "$TMP_DIR/ffmpeg" "$FFMPEG_DEST"
+    chmod +x "$FFMPEG_DEST"
+    rm -rf "$TMP_DIR"
+    echo "    ffmpeg downloaded: $(${FFMPEG_DEST} -version 2>&1 | head -1)"
+else
+    echo "==> ffmpeg already present, skipping download."
+fi
+
+# ── Bundle static exiftool ────────────────────────────────────────────────────
+EXIFTOOL_DEST="Assets/exiftool"
+if [ ! -f "$EXIFTOOL_DEST" ]; then
+    echo "==> Downloading static exiftool..."
+    EXIFTOOL_VER=$(curl -s https://exiftool.org/ver.txt)
+    EXIFTOOL_URL="https://exiftool.org/Image-ExifTool-${EXIFTOOL_VER}.tar.gz"
+    TMP_DIR=$(mktemp -d)
+    wget -q --show-progress -O "$TMP_DIR/exiftool.tar.gz" "$EXIFTOOL_URL"
+    tar -xf "$TMP_DIR/exiftool.tar.gz" -C "$TMP_DIR" --strip-components=1
+    cp "$TMP_DIR/exiftool" "$EXIFTOOL_DEST"
+    chmod +x "$EXIFTOOL_DEST"
+    # Copy the lib directory exiftool needs alongside it
+    cp -r "$TMP_DIR/lib" "Assets/exiftool_lib"
+    rm -rf "$TMP_DIR"
+    echo "    exiftool downloaded."
+else
+    echo "==> exiftool already present, skipping download."
+fi
+
+echo "==> Installing Python dependencies..."
+pip install --quiet -r requirements.txt
+pip install --quiet pyinstaller
+
+echo "==> Running PyInstaller..."
+pyinstaller --clean --noconfirm QualityScaler.spec
+
+echo "==> Creating AppDir structure..."
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin"
+mkdir -p "$APPDIR/usr/share/applications"
+mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+cp -r "dist/$APPNAME/." "$APPDIR/usr/bin/"
+
+# Bundle CUDA libs from nvidia-* pip packages so the AppImage is self-contained.
+echo "==> Bundling CUDA libraries from nvidia pip packages..."
+mkdir -p "$APPDIR/usr/lib/cuda"
+SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
+for pkg_lib_dir in "$SITE_PACKAGES"/nvidia/*/lib; do
+    if [ -d "$pkg_lib_dir" ]; then
+        find "$pkg_lib_dir" -maxdepth 1 -name "*.so*" -exec cp -n {} "$APPDIR/usr/lib/cuda/" \;
+    fi
+done
+echo "    Bundled $(ls "$APPDIR/usr/lib/cuda/" | wc -l) CUDA library files."
+
+# Desktop entry
+cat > "$APPDIR/usr/share/applications/$APPNAME.desktop" <<EOF
+[Desktop Entry]
+Name=$APPNAME
+Exec=$APPNAME
+Icon=$APPNAME
+Type=Application
+Categories=Graphics;
+EOF
+
+# Icon
+if [ -f "Assets/logo.png" ]; then
+    cp "Assets/logo.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/$APPNAME.png"
+fi
+
+# AppDir root symlinks required by AppImage spec
+cp "$APPDIR/usr/share/applications/$APPNAME.desktop" "$APPDIR/$APPNAME.desktop"
+cp "$APPDIR/usr/share/icons/hicolor/256x256/apps/$APPNAME.png" "$APPDIR/$APPNAME.png" 2>/dev/null || true
+
+# AppRun entry point
+cat > "$APPDIR/AppRun" <<'EOF'
+#!/bin/bash
+SELF=$(readlink -f "$0")
+HERE=$(dirname "$SELF")
+export PATH="$HERE/usr/bin:$PATH"
+
+# Prepend bundled CUDA libs (copied from nvidia-* pip packages at build time).
+export LD_LIBRARY_PATH="$HERE/usr/lib/cuda${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+exec "$HERE/usr/bin/QualityScaler" "$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+echo "==> Packaging AppImage..."
+rm -f "${APPNAME}-${VERSION}-x86_64.AppImage"
+APPIMAGETOOL=""
+if command -v appimagetool &>/dev/null; then
+    APPIMAGETOOL="appimagetool"
+elif [ -f "./appimagetool-x86_64.AppImage" ]; then
+    APPIMAGETOOL="./appimagetool-x86_64.AppImage"
+else
+    echo ""
+    echo "appimagetool not found. Download it and re-run:"
+    echo "  wget -q 'https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage'"
+    echo "  chmod +x appimagetool-x86_64.AppImage"
+    echo ""
+    echo "PyInstaller bundle is ready in dist/$APPNAME/ — you can run it directly:"
+    echo "  ./dist/$APPNAME/$APPNAME"
+    exit 0
+fi
+
+ARCH=x86_64 $APPIMAGETOOL "$APPDIR" "${APPNAME}-${VERSION}-x86_64.AppImage"
+echo ""
+echo "Done: ${APPNAME}-${VERSION}-x86_64.AppImage"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,12 @@
 #AI
-onnxruntime-directml==1.24.4
+# 1.18.x is the last release supporting cuDNN 8, required for Pascal GPUs (GTX 1080, sm_61)
+# cuDNN 9 (used by 1.19+) requires sm_70 (Volta) or newer
+onnxruntime-gpu==1.18.1
+nvidia-cuda-runtime-cu11
+nvidia-cudnn-cu11
+nvidia-cublas-cu11
+nvidia-cufft-cu11
+nvidia-curand-cu11
 numpy
 
 #GUI


### PR DESCRIPTION
This PR ports QualityScaler to Linux, distributed as a self-contained AppImage that requires no installation beyond an NVIDIA driver.

Changes:
- QualityScaler.py — Linux compatibility fixes: iconphoto() instead of iconbitmap() (Linux only accepts .xbm), native file dialogs via zenity/kdialog with tkinter fallback, corrected subprocess calls (shell=False bool — the original shell="False" string is truthy and caused ffmpeg to receive no arguments)
- requirements.txt — replaces onnxruntime-directml with onnxruntime-gpu 1.18.1 for NVIDIA CUDA acceleration. Pinned to 1.18.1 because 1.19+ uses cuDNN 9 which dropped Pascal GPU support (sm_61, GTX 10xx)
- build-appimage.sh — builds a self-contained AppImage bundling Python, CUDA libraries, static ffmpeg/exiftool, and AI models
- QualityScaler.spec — PyInstaller spec updated for Linux, includes PIL.ImageTk hidden imports (system Pillow on Linux is headless)
- .github/workflows/release.yml — builds and publishes the AppImage on tag push
- README.md — added Linux prerequisites and getting started section